### PR TITLE
Switch to use Bitrise

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 ![Swift Package Manager and Carthage and CocoaPods compatible](https://img.shields.io/badge/SPM%20%7C%20Carthage%20%7C%20CocoaPods-compatible-green.svg)
 [![v2.0.0](https://img.shields.io/badge/version-2.0.0-blue.svg)](https://github.com/Kuniwak/MirrorDiffKit/releases)
 [![MIT license](https://img.shields.io/badge/lisence-MIT-yellow.svg)](https://github.com/Kuniwak/MirrorDiffKit/blob/master/LICENSE)
-[![CircleCI](https://circleci.com/gh/Kuniwak/MirrorDiffKit/tree/master.svg?style=shield)](https://circleci.com/gh/Kuniwak/MirrorDiffKit/tree/master)
+[![Build Status](https://www.bitrise.io/app/94e8fe199a9a670b/status.svg?token=XaNhf80F5x3pimGVlyPb-w&branch=master)](https://www.bitrise.io/app/94e8fe199a9a670b)
 
 
 A tool for providing the 2 features for efficient testing:


### PR DESCRIPTION
Because it is hard to mock CoreGraphics Objects such as CGFloat on Linux.